### PR TITLE
adapt rust runtime to api changes from upstream

### DIFF
--- a/runtime/rust_backend/Runtime.cpp
+++ b/runtime/rust_backend/Runtime.cpp
@@ -123,8 +123,8 @@ SymExpr _sym_build_float(double value, int is_double) {
       symexpr(_rsym_build_float(value, is_double), is_double ? 64 : 32));
 }
 
-SymExpr _sym_get_input_byte(size_t offset) {
-  return registerExpression(symexpr(_rsym_get_input_byte(offset), 8));
+SymExpr _sym_get_input_byte(size_t offset, uint8_t value) {
+  return registerExpression(symexpr(_rsym_get_input_byte(offset, value), 8));
 }
 
 SymExpr _sym_build_null_pointer(void) {
@@ -280,9 +280,9 @@ SymExpr _sym_build_float_to_unsigned_integer(SymExpr expr, uint8_t bits) {
       _rsym_build_float_to_unsigned_integer(symexpr_id(expr), bits), bits));
 }
 
-SymExpr _sym_build_bool_to_bits(SymExpr expr, uint8_t bits) {
+SymExpr _sym_build_bool_to_bit(SymExpr expr, uint8_t bits) {
   return registerExpression(
-      symexpr(_rsym_build_bool_to_bits(symexpr_id(expr), bits), bits));
+      symexpr(_rsym_build_bool_to_bit(symexpr_id(expr), bits), bits));
 }
 
 void _sym_push_path_constraint(SymExpr constraint, int taken,

--- a/runtime/rust_backend/RustRuntime.h
+++ b/runtime/rust_backend/RustRuntime.h
@@ -116,7 +116,7 @@ RSymExpr _rsym_build_bits_to_float(RSymExpr expr, bool to_double);
 RSymExpr _rsym_build_float_to_bits(RSymExpr expr);
 RSymExpr _rsym_build_float_to_signed_integer(RSymExpr expr, uint8_t bits);
 RSymExpr _rsym_build_float_to_unsigned_integer(RSymExpr expr, uint8_t bits);
-RSymExpr _rsym_build_bool_to_bits(RSymExpr expr, uint8_t bits);
+RSymExpr _rsym_build_bool_to_bit(RSymExpr expr, uint8_t bits);
 
 /*
  * Bit-array helpers
@@ -129,7 +129,7 @@ RSymExpr _rsym_extract_helper(RSymExpr expr, size_t first_bit, size_t last_bit);
  */
 void _rsym_push_path_constraint(RSymExpr constraint, bool taken,
                                 uintptr_t site_id);
-RSymExpr _rsym_get_input_byte(size_t offset);
+RSymExpr _rsym_get_input_byte(size_t offset, uint8_t value);
 
 /*
  * Call-stack tracing


### PR DESCRIPTION
There were upstream changes to the api between the instrumented program and the runtime that I hadn't accounted for in my previous PR #3 .