### PR TITLE
Remove extern block from RustRuntime.h

### DIFF
--- a/runtime/rust_backend/RustRuntime.h
+++ b/runtime/rust_backend/RustRuntime.h
@@ -24,13 +24,7 @@
 #define RUSTRUNTIME_H
 
 #include <stddef.h>
-
-#ifdef __cplusplus
 #include <cstdint>
-extern "C" {
-#else
-#include <stdint.h>
-#endif
 
 typedef uintptr_t RSymExpr;
 
@@ -144,9 +138,3 @@ void _rsym_notify_basic_block(uintptr_t site_id);
  * Garbage collection
  */
 void _rsym_expression_unreachable(RSymExpr *expressions, size_t num_elements);
-
-#ifdef __cplusplus
-}
-#endif
-
-#endif

--- a/runtime/rust_backend/RustRuntime.h
+++ b/runtime/rust_backend/RustRuntime.h
@@ -23,8 +23,8 @@
 #ifndef RUSTRUNTIME_H
 #define RUSTRUNTIME_H
 
-#include <stddef.h>
 #include <cstdint>
+#include <stddef.h>
 
 typedef uintptr_t RSymExpr;
 

--- a/runtime/rust_backend/RustRuntime.h
+++ b/runtime/rust_backend/RustRuntime.h
@@ -138,3 +138,5 @@ void _rsym_notify_basic_block(uintptr_t site_id);
  * Garbage collection
  */
 void _rsym_expression_unreachable(RSymExpr *expressions, size_t num_elements);
+
+#endif


### PR DESCRIPTION
Because rust bindgen do not generate any bindings for things inside the extern "C" block.

and so just deem this file as C++ file